### PR TITLE
feat: multiple assigned users

### DIFF
--- a/app/Actions/Task/CreateTask.php
+++ b/app/Actions/Task/CreateTask.php
@@ -29,7 +29,7 @@ class CreateTask
             $task = $project->tasks()->create([
                 'group_id' => $data['group_id'],
                 'created_by_user_id' => auth()->id(),
-                'assigned_to_user_id' => $data['assigned_to_user_id'],
+                'assigned_users' => $data['assigned_users'],
                 'name' => $data['name'],
                 'number' => $project->tasks()->withArchived()->count() + 1,
                 'description' => $data['description'],
@@ -45,6 +45,8 @@ class CreateTask
             $task->moveToStart();
 
             $task->subscribedUsers()->attach($data['subscribed_users'] ?? []);
+
+            $task->assignedUsers()->sync($data['assigned_users'] ?? []);
 
             $task->labels()->attach($data['labels'] ?? []);
 

--- a/app/Actions/Task/UpdateTask.php
+++ b/app/Actions/Task/UpdateTask.php
@@ -23,6 +23,10 @@ class UpdateTask
             $data['fixed_price'] = (int) $data['fixed_price'];
         }
 
+        if ($updateField === 'assigned_users') {
+            $task->assignedUsers()->sync($data['assigned_users']);
+        }
+
         if (! in_array($updateField, ['subscribed_users', 'labels'])) {
             $task->update($data);
 

--- a/app/Http/Controllers/MyWork/MyWorkTaskController.php
+++ b/app/Http/Controllers/MyWork/MyWorkTaskController.php
@@ -23,7 +23,9 @@ class MyWorkTaskController extends Controller
                     'clientCompany:id,name',
                     'tasks' => function ($query) use ($user) {
                         $query->when($user->hasRole('client'), fn ($query) => $query->where('hidden_from_clients', false))
-                            ->where('assigned_to_user_id', $user->id)
+                            ->whereHas('assignedUsers', function ($query) use ($user) {
+                                $query->where('user_id', $user->id);
+                            })
                             ->whereNull('completed_at')
                             ->withoutGlobalScope('ordered')
                             ->orderByRaw('-due_on DESC')

--- a/app/Http/Requests/Task/StoreTaskRequest.php
+++ b/app/Http/Requests/Task/StoreTaskRequest.php
@@ -26,7 +26,7 @@ class StoreTaskRequest extends FormRequest
         return [
             'name' => ['required', 'string:255'],
             'group_id' => ['required', 'exists:task_groups,id'],
-            'assigned_to_user_id' => ['nullable', 'exists:users,id'],
+            'assigned_users' => ['array'],
             'description' => ['nullable'],
             'estimation' => ['nullable'],
             'pricing_type' => ['required', 'string', Rule::enum(PricingType::class)],

--- a/app/Http/Requests/Task/UpdateTaskRequest.php
+++ b/app/Http/Requests/Task/UpdateTaskRequest.php
@@ -26,7 +26,7 @@ class UpdateTaskRequest extends FormRequest
         return [
             'name' => ['string:255'],
             'group_id' => ['exists:task_groups,id'],
-            'assigned_to_user_id' => ['nullable', 'exists:users,id'],
+            'assigned_users' => ['array'],
             'description' => ['nullable'],
             'estimation' => ['nullable'],
             'pricing_type' => ['string', Rule::enum(PricingType::class)],

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -79,13 +79,14 @@ class Task extends Model implements AuditableContract, Sortable
         'labels:id,name,color',
         'attachments',
         'timeLogs.user:id,name',
+        'assignedUsers:id,name,avatar',
     ];
 
     public function filters(): array
     {
         return [
             (new WhereInFilter('group_id'))->setQueryName('groups'),
-            (new WhereInFilter('assigned_to_user_id'))->setQueryName('assignees'),
+            (new WhereHasFilter('assignedUsers'))->setQueryName('assignedUsers'),
             (new TaskOverdueFilter('due_on'))->setQueryName('overdue'),
             (new IsNullFilter('due_on'))->setQueryName('not_set'),
             (new TaskCompletedFilter('completed_at'))->setQueryName('status'),
@@ -138,6 +139,11 @@ class Task extends Model implements AuditableContract, Sortable
     public function subscribedUsers(): BelongsToMany
     {
         return $this->belongsToMany(User::class, 'subscribe_task');
+    }
+
+    public function assignedUsers(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class)->using(TaskUser::class)->withTimestamps();
     }
 
     public function labels(): BelongsToMany

--- a/app/Models/TaskUser.php
+++ b/app/Models/TaskUser.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+class TaskUser extends Pivot
+{
+
+    protected $table = 'task_user';
+
+    public function task()
+    {
+        return $this->belongsTo(Task::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -83,6 +83,7 @@ class User extends Authenticatable implements AuditableContract, CanResetPasswor
     {
         return $this->belongsToMany(Project::class, 'project_user_access');
     }
+    
 
     public function subscribedToTasks(): BelongsToMany
     {
@@ -112,5 +113,10 @@ class User extends Authenticatable implements AuditableContract, CanResetPasswor
             ->get(['id', 'name'])
             ->map(fn ($i) => ['value' => (string) $i->id, 'label' => $i->name])
             ->toArray();
+    }
+
+    public function tasks()
+    {
+        return $this->belongsToMany(Task::class)->using(TaskUser::class)->withTimestamps();
     }
 }

--- a/app/Observers/TaskUserObserver.php
+++ b/app/Observers/TaskUserObserver.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\TaskUser;
+
+class TaskUserObserver
+{
+
+    public function created(TaskUser $taskUser): void
+    {
+        $taskUser->load('task', 'user');
+        $task = $taskUser->task;
+        $task->activities()->create([
+            'project_id' => $task->project_id,
+            'user_id' => auth()->id(),
+            'title' => 'Assigned user to task',
+            'subtitle' => "{$taskUser->user->name} was added to task \"{$task->name}\" by " . auth()->user()->name,
+        ]);
+        $task->assigned_at = now();
+        $task->saveQuietly();
+    }
+
+    public function deleted(TaskUser $taskUser): void
+    {
+        $taskUser->load('task', 'user:id,name');
+        $task = $taskUser->task;
+        $task->activities()->create([
+            'project_id' => $task->project_id,
+            'user_id' => auth()->id(),
+            'title' => 'Assigned user was removed',
+            'subtitle' => "{$taskUser->user->name} was removed from task \"{$task->name}\" by " . auth()->user()->name,
+        ]);
+        $task->assigned_at = now();
+        $task->saveQuietly();
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -10,9 +10,11 @@ use App\Listeners\SendEmailWithCredentials;
 use App\Models\Comment;
 use App\Models\Project;
 use App\Models\Task;
+use App\Models\TaskUser;
 use App\Observers\CommentObserver;
 use App\Observers\ProjectObserver;
 use App\Observers\TaskObserver;
+use App\Observers\TaskUserObserver;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Event;
 
@@ -43,6 +45,7 @@ class EventServiceProvider extends ServiceProvider
     protected $observers = [
         Project::class => [ProjectObserver::class],
         Task::class => [TaskObserver::class],
+        TaskUser::class => [TaskUserObserver::class],
         Comment::class => [CommentObserver::class],
     ];
 

--- a/database/migrations/2025_04_14_132049_create_task_user_table.php
+++ b/database/migrations/2025_04_14_132049_create_task_user_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Models\Task;
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('task_user', function (Blueprint $table) {
+            $table->foreignIdFor(Task::class)->constrained()->cascadeOnDelete();
+            $table->foreignIdFor(User::class)->constrained()->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->primary(['task_id', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('task_user');
+    }
+};

--- a/database/seeders/MigrateTaskAssignedToUserIdToAssignedUsers.php
+++ b/database/seeders/MigrateTaskAssignedToUserIdToAssignedUsers.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Task;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Auth;
+
+class MigrateTaskAssignedToUserIdToAssignedUsers extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Auth::loginUsingId(1);
+        $tasks = Task::get();
+        foreach ($tasks as $task) {
+            if ($task->assigned_to_user_id == null) {
+                continue;
+            }
+            $task->assignees()->sync([$task->assigned_to_user_id]);
+            $task->update(['assigned_to_user_id' => null]);
+        }
+    }
+}

--- a/resources/js/pages/Dashboard/Cards/RecentlyAssignedTasks.jsx
+++ b/resources/js/pages/Dashboard/Cards/RecentlyAssignedTasks.jsx
@@ -50,9 +50,9 @@ export default function RecentlyAssignedTasks({ tasks }) {
                       </Text>
                     </Group>
                   </Stack>
-                  <Tooltip label={date(task.assigned_at)} openDelay={500} withArrow>
+                  <Tooltip label={date(task.assigned_users[0].created_at)} openDelay={500} withArrow>
                     <Text fz={11} fw={700} className={classes.due}>
-                      {diffForHumans(task.assigned_at)}
+                      {diffForHumans(task.assigned_users[0].created_at)}
                     </Text>
                   </Tooltip>
                 </Group>

--- a/resources/js/pages/Projects/Tasks/Drawers/CreateTaskDrawer.jsx
+++ b/resources/js/pages/Projects/Tasks/Drawers/CreateTaskDrawer.jsx
@@ -198,18 +198,18 @@ export function CreateTaskDrawer() {
             error={form.errors.group_id}
           />
 
-          <Select
-            label='Assignee'
-            placeholder='Select assignee'
+          <MultiSelect
+            label="Assignees"
+            placeholder="Select assignees"
             searchable
-            mt='md'
-            value={form.data.assigned_to_user_id}
-            onChange={value => updateValue('assigned_to_user_id', value)}
-            data={usersWithAccessToProject.map(i => ({
+            mt="md"
+            value={form.data.assigned_users}
+            onChange={(values) => updateValue("assigned_users", values)}
+            data={usersWithAccessToProject.map((i) => ({
               value: i.id.toString(),
               label: i.name,
             }))}
-            error={form.errors.assigned_to_user_id}
+            error={form.errors.assigned_users}
           />
 
           <DateInput

--- a/resources/js/pages/Projects/Tasks/Drawers/EditTaskDrawer.jsx
+++ b/resources/js/pages/Projects/Tasks/Drawers/EditTaskDrawer.jsx
@@ -50,7 +50,7 @@ export function EditTaskDrawer() {
 
   const [data, setData] = useState({
     group_id: '',
-    assigned_to_user_id: '',
+    assigned_users: [],
     name: '',
     description: '',
     pricing_type: PricingType.HOURLY,
@@ -73,7 +73,7 @@ export function EditTaskDrawer() {
     if (edit.opened) {
       setData({
         group_id: task?.group_id || '',
-        assigned_to_user_id: task?.assigned_to_user_id || '',
+        assigned_users: (task?.assigned_users || []).map((i) => i.id.toString()),
         name: task?.name || '',
         description: task?.description || '',
         pricing_type: task?.pricing_type || PricingType.HOURLY,
@@ -95,7 +95,7 @@ export function EditTaskDrawer() {
   const updateValue = (field, value) => {
     setData({ ...data, [field]: value });
 
-    const dropdowns = ['labels', 'subscribed_users'];
+    const dropdowns = ['labels', 'subscribed_users','assigned_users'];
     const onBlurInputs = ['name', 'description', 'fixed_price'];
 
     if (dropdowns.includes(field)) {
@@ -103,6 +103,9 @@ export function EditTaskDrawer() {
         labels: value.map(id => labels.find(i => i.id === id)),
         subscribed_users: value.map(id =>
           usersWithAccessToProject.find(i => i.id.toString() === id)
+        ),
+        assigned_users: value.map((id) =>
+          usersWithAccessToProject.find((i) => i.id.toString() === id),
         ),
       };
       updateTaskProperty(task, field, value, options[field]);
@@ -230,13 +233,12 @@ export function EditTaskDrawer() {
                 readOnly={!can('edit task')}
               />
 
-              <Select
-                label='Assignee'
-                placeholder='Select assignee'
-                searchable
-                mt='md'
-                value={data.assigned_to_user_id?.toString()}
-                onChange={value => updateValue('assigned_to_user_id', value)}
+              <MultiSelect
+                label="Assigned Users"
+                placeholder={!data.assigned_users.length ? "Select assigned users" : null}
+                mt="lg"
+                value={data.assigned_users}
+                onChange={(values) => updateValue("assigned_users", values)}
                 data={usersWithAccessToProject.map(i => ({
                   value: i.id.toString(),
                   label: i.name,

--- a/resources/js/pages/Projects/Tasks/Index/Task/TaskCard.jsx
+++ b/resources/js/pages/Projects/Tasks/Index/Task/TaskCard.jsx
@@ -33,7 +33,7 @@ export default function TaskCard({ task, index }) {
               #{task.number + ": " + task.name}
             </Text>
 
-            <Group wrap="nowrap" justify="space-between">
+            <Group wrap="nowrap"  style={{ justifyContent: "flex-end", gap: rem(5) }}>
               <Group wrap="wrap" style={{ rowGap: rem(3), columnGap: rem(12) }} mt={5}>
                 {task.labels.map((label) => (
                   <Label
@@ -46,24 +46,27 @@ export default function TaskCard({ task, index }) {
                 ))}
               </Group>
 
-              {task.assigned_to_user && (
-                <Tooltip label={task.assigned_to_user.name} openDelay={1000} withArrow>
-                  <Link
-                    href={route("users.edit", task.assigned_to_user.id)}
-                    style={{ textDecoration: "none" }}
-                  >
-                    <Avatar
-                      src={task.assigned_to_user.avatar}
-                      radius="xl"
-                      size={20}
-                      color={computedColorScheme === "light" ? "white" : "blue"}
+              {task.assigned_users?.length > 0 && (
+                <>
+                  {task.assigned_users.map((user) => (
+                    <Tooltip label={user.name} openDelay={1000} withArrow>
+                    <Link
+                      href={route("users.edit", user.id)}
+                      style={{ textDecoration: "none" }}
                     >
-                      {getInitials(task.assigned_to_user.name)}
-                    </Avatar>
-                  </Link>
-                </Tooltip>
+                      <Avatar
+                        src={user.avatar}
+                        radius="xl"
+                        size={20}
+                        color={computedColorScheme === "light" ? "white" : "blue"}
+                      >
+                        {getInitials(user.name)}
+                      </Avatar>
+                    </Link>
+                  </Tooltip>
+                  ))}
+                </>
               )}
-
               {(can("archive task") || can("restore task")) && (
                 <TaskActions task={task} className={classes.actions} />
               )}

--- a/resources/js/pages/Projects/Tasks/Index/Task/TaskRow.jsx
+++ b/resources/js/pages/Projects/Tasks/Index/Task/TaskRow.jsx
@@ -46,14 +46,18 @@ export default function TaskRow({ task, index }) {
               onChange={(e) => complete(task, e.currentTarget.checked)}
               className={can("complete task") ? classes.checkbox : classes.disabledCheckbox}
             />
-            {task.assigned_to_user && (
-              <Link href={route("users.edit", task.assigned_to_user.id)}>
-                <Tooltip label={task.assigned_to_user.name} openDelay={1000} withArrow>
-                  <Pill size="sm" className={classes.user}>
-                    {shortName(task.assigned_to_user.name)}
-                  </Pill>
-                </Tooltip>
-              </Link>
+            {task.assigned_users?.length > 0 && (
+              <>
+                {task.assigned_users.map((user) => (
+                  <Link key={user.id} href={route("users.edit", user.id)}>
+                    <Tooltip label={user.name} openDelay={1000} withArrow>
+                      <Pill size="sm" className={classes.user}>
+                        {shortName(user.name)}
+                      </Pill>
+                    </Tooltip>
+                  </Link>
+                ))}
+              </>
             )}
             <Text
               className={classes.name}


### PR DESCRIPTION
This will enable assigning of multiple users to a task

includes functions in
dashboard, tasks and activities

this removes the all functions using assigned_to_user_id in tasks table
and converted to many-to-many relationship to task_user table

dependents

migrations of 

2025_04_14_132049_create_task_user_table

and seeder to migrate existing users to multiple assigned users

MigrateTaskAssignedToUserIdToAssignedUsers