### PR TITLE
Feature/task group color

### DIFF
--- a/app/Http/Requests/TaskGroup/StoreTaskGroupRequest.php
+++ b/app/Http/Requests/TaskGroup/StoreTaskGroupRequest.php
@@ -22,13 +22,19 @@ class StoreTaskGroupRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
-            'name' => [
-                'required',
-                'string',
-                Rule::unique('task_groups', 'name')
-                    ->where('project_id', $this->route('project')->id),
-            ],
-        ];
+         return [
+        'name' => [
+            'required',
+            'string',
+            Rule::unique('task_groups', 'name')
+                ->where('project_id', $this->route('project')->id)
+                ->ignore($this->route('taskGroup')->id),
+        ],
+        'color' => [
+            'nullable',
+            'string',
+            'max:16',
+        ],
+         ];
     }
 }

--- a/app/Http/Requests/TaskGroup/UpdateTaskGroupRequest.php
+++ b/app/Http/Requests/TaskGroup/UpdateTaskGroupRequest.php
@@ -22,14 +22,19 @@ class UpdateTaskGroupRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
-            'name' => [
-                'required',
-                'string',
-                Rule::unique('task_groups', 'name')
-                    ->where('project_id', $this->route('project')->id)
-                    ->ignore($this->route('taskGroup')->id),
-            ],
-        ];
+         return [
+        'name' => [
+            'required',
+            'string',
+            Rule::unique('task_groups', 'name')
+                ->where('project_id', $this->route('project')->id)
+                ->ignore($this->route('taskGroup')->id),
+        ],
+        'color' => [
+            'nullable',
+            'string',
+            'max:16',
+        ],
+         ];
     }
 }

--- a/app/Models/TaskGroup.php
+++ b/app/Models/TaskGroup.php
@@ -19,7 +19,7 @@ class TaskGroup extends Model implements AuditableContract, Sortable
 
     public $timestamps = false;
 
-    protected $fillable = ['name', 'project_id', 'order_column'];
+    protected $fillable = ['name','color', 'project_id', 'order_column'];
 
     protected static function booted(): void
     {

--- a/database/migrations/2025_12_15_090401_add_color_to_task_groups_table.php
+++ b/database/migrations/2025_12_15_090401_add_color_to_task_groups_table.php
@@ -1,0 +1,21 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('task_groups', function (Blueprint $table) {
+            $table->string('color', 16)->nullable()->after('name');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('task_groups', function (Blueprint $table) {
+            $table->dropColumn('color');
+        });
+    }
+};

--- a/resources/js/hooks/store/useSidebarStore.js
+++ b/resources/js/hooks/store/useSidebarStore.js
@@ -1,0 +1,9 @@
+import { create } from 'zustand';
+
+const useSidebarStore = create((set) => ({
+  collapsed: false,
+  toggle: () => set((state) => ({ collapsed: !state.collapsed })),
+  setCollapsed: (collapsed) => set({ collapsed }),
+}));
+
+export default useSidebarStore;

--- a/resources/js/hooks/useSidebarCollapse.js
+++ b/resources/js/hooks/useSidebarCollapse.js
@@ -1,7 +1,0 @@
-import { useState } from "react";
-
-export default function useSidebarCollapse(initial = false) {
-  const [collapsed, setCollapsed] = useState(initial);
-  const toggle = () => setCollapsed((c) => !c);
-  return { collapsed, toggle };
-}

--- a/resources/js/hooks/useSidebarCollapse.js
+++ b/resources/js/hooks/useSidebarCollapse.js
@@ -1,0 +1,7 @@
+import { useState } from "react";
+
+export default function useSidebarCollapse(initial = false) {
+  const [collapsed, setCollapsed] = useState(initial);
+  const toggle = () => setCollapsed((c) => !c);
+  return { collapsed, toggle };
+}

--- a/resources/js/layouts/MainLayout.jsx
+++ b/resources/js/layouts/MainLayout.jsx
@@ -3,12 +3,14 @@ import useNotificationsStore from "@/hooks/store/useNotificationsStore";
 import useAuthorization from "@/hooks/useAuthorization";
 import useWebSockets from "@/hooks/useWebSockets";
 import NavBarNested from "@/layouts/NavBarNested";
+import useSidebarCollapse from "@/hooks/useSidebarCollapse";
 import Notifications from "@/layouts/Notifications";
 import { Head, usePage } from "@inertiajs/react";
 import { AppShell } from "@mantine/core";
 import { useEffect } from "react";
 
 export default function MainLayout({ children, title }) {
+  const { collapsed, toggle } = useSidebarCollapse(false);
   window.can = useAuthorization().can;
 
   const { initUserWebSocket } = useWebSockets();
@@ -22,7 +24,7 @@ export default function MainLayout({ children, title }) {
 
   return (
     <AppShell
-      navbar={{ width: 300, breakpoint: "sm", collapsed: { mobile: false } }}
+      navbar={{ width: collapsed ? 60 : 260, breakpoint: "sm", collapsed: { mobile: false } }}
       padding="4rem"
     >
       <Head title={title} />
@@ -32,7 +34,7 @@ export default function MainLayout({ children, title }) {
       <Notifications />
 
       <AppShell.Navbar>
-        <NavBarNested></NavBarNested>
+        <NavBarNested collapsed={collapsed} toggle={toggle} />
       </AppShell.Navbar>
 
       <AppShell.Main>{children}</AppShell.Main>

--- a/resources/js/layouts/MainLayout.jsx
+++ b/resources/js/layouts/MainLayout.jsx
@@ -1,16 +1,16 @@
 import FlashNotification from "@/components/FlashNotification";
 import useNotificationsStore from "@/hooks/store/useNotificationsStore";
+import useSidebarStore from "@/hooks/store/useSidebarStore";
 import useAuthorization from "@/hooks/useAuthorization";
 import useWebSockets from "@/hooks/useWebSockets";
 import NavBarNested from "@/layouts/NavBarNested";
-import useSidebarCollapse from "@/hooks/useSidebarCollapse";
 import Notifications from "@/layouts/Notifications";
 import { Head, usePage } from "@inertiajs/react";
 import { AppShell } from "@mantine/core";
 import { useEffect } from "react";
 
 export default function MainLayout({ children, title }) {
-  const { collapsed, toggle } = useSidebarCollapse(false);
+  const { collapsed } = useSidebarStore();
   window.can = useAuthorization().can;
 
   const { initUserWebSocket } = useWebSockets();
@@ -34,7 +34,7 @@ export default function MainLayout({ children, title }) {
       <Notifications />
 
       <AppShell.Navbar>
-        <NavBarNested collapsed={collapsed} toggle={toggle} />
+        <NavBarNested />
       </AppShell.Navbar>
 
       <AppShell.Main>{children}</AppShell.Main>

--- a/resources/js/layouts/NavBarNested.jsx
+++ b/resources/js/layouts/NavBarNested.jsx
@@ -1,7 +1,7 @@
 import Logo from "@/components/Logo";
 import useNavigationStore from "@/hooks/store/useNavigationStore";
+import useSidebarCollapse from "@/hooks/useSidebarCollapse";
 import { usePage } from "@inertiajs/react";
-import { Group, ScrollArea, Text, rem } from "@mantine/core";
 import {
   IconBuildingSkyscraper,
   IconFileDollar,
@@ -11,13 +11,17 @@ import {
   IconReportAnalytics,
   IconSettings,
   IconUsers,
+  IconChevronLeft,
+  IconChevronRight
 } from "@tabler/icons-react";
 import { useEffect } from "react";
+
 import NavbarLinksGroup from "./NavbarLinksGroup";
 import UserButton from "./UserButton";
 import classes from "./css/NavBarNested.module.css";
+import { Group, ScrollArea, Text, rem, ActionIcon, Transition } from "@mantine/core";
 
-export default function Sidebar() {
+export default function Sidebar({ collapsed, toggle }) {
   const { version } = usePage().props;
   const { items, setItems } = useNavigationStore();
 
@@ -151,28 +155,38 @@ export default function Sidebar() {
   }, []);
 
   return (
-    <nav className={classes.navbar}>
+    <nav
+      className={classes.navbar}
+        style={{ width: collapsed ? 60 : 260, transition: "width 0.2s cubic-bezier(0.4, 0.0, 0.2, 1)" }}
+    >
       <div className={classes.header}>
         <Group justify="space-between">
-          <Logo style={{ width: rem(120) }} />
-          <Text size="xs" className={classes.version}>
-            v{version}
-          </Text>
+          {!collapsed && <Logo style={{ width: rem(120) }} />}
+          {!collapsed && (
+            <Text size="xs" className={classes.version}>
+              v{version}
+            </Text>
+          )}
+          <ActionIcon variant="light" onClick={toggle} size={32} aria-label="Toggle sidebar">
+            {collapsed ? <IconChevronRight size={20} /> : <IconChevronLeft size={20} />}
+          </ActionIcon>
         </Group>
       </div>
 
-      <ScrollArea className={classes.links}>
-        <div className={classes.linksInner}>
-          {items
-            .filter((i) => i.visible)
-            .map((item) => (
-              <NavbarLinksGroup key={item.label} item={item} />
-            ))}
-        </div>
-      </ScrollArea>
+      {!collapsed && (
+        <ScrollArea className={classes.links}>
+          <div className={classes.linksInner}>
+            {items
+              .filter((i) => i.visible)
+              .map((item) => (
+                <NavbarLinksGroup key={item.label} item={item} />
+              ))}
+          </div>
+        </ScrollArea>
+      )}
 
       <div className={classes.footer}>
-        <UserButton />
+        {!collapsed && <UserButton />}
       </div>
     </nav>
   );

--- a/resources/js/layouts/NavBarNested.jsx
+++ b/resources/js/layouts/NavBarNested.jsx
@@ -1,6 +1,6 @@
 import Logo from "@/components/Logo";
 import useNavigationStore from "@/hooks/store/useNavigationStore";
-import useSidebarCollapse from "@/hooks/useSidebarCollapse";
+import useSidebarStore from "@/hooks/store/useSidebarStore";
 import { usePage } from "@inertiajs/react";
 import {
   IconBuildingSkyscraper,
@@ -21,9 +21,10 @@ import UserButton from "./UserButton";
 import classes from "./css/NavBarNested.module.css";
 import { Group, ScrollArea, Text, rem, ActionIcon, Transition } from "@mantine/core";
 
-export default function Sidebar({ collapsed, toggle }) {
+export default function Sidebar() {
   const { version } = usePage().props;
   const { items, setItems } = useNavigationStore();
+  const { collapsed, toggle } = useSidebarStore();
 
   useEffect(() => {
     setItems([

--- a/resources/js/pages/Projects/Tasks/Index/Modals/EditTasksGroupModal.jsx
+++ b/resources/js/pages/Projects/Tasks/Index/Modals/EditTasksGroupModal.jsx
@@ -1,5 +1,5 @@
 import useForm from "@/hooks/useForm";
-import { Button, Flex, Text, TextInput } from "@mantine/core";
+import { Button, Flex, Text, TextInput, ColorInput } from "@mantine/core";
 import { modals } from "@mantine/modals";
 
 function ModalForm({ item }) {
@@ -9,6 +9,7 @@ function ModalForm({ item }) {
     {
       _method: "put",
       name: item.name || "",
+      color: item.color || "",
     },
   );
 
@@ -29,6 +30,31 @@ function ModalForm({ item }) {
         value={form.data.name}
         onChange={(e) => updateValue("name", e.target.value)}
         error={form.errors.name}
+      />
+
+      <ColorInput
+        label="Color"
+        placeholder="Group color"
+        mt="md"
+        swatches={[
+          "#343A40",
+          "#E03231",
+          "#C2255C",
+          "#9C36B5",
+          "#6741D9",
+          "#3B5BDB",
+          "#2771C2",
+          "#2A8599",
+          "#2B9267",
+          "#309E44",
+          "#66A810",
+          "#F08C00",
+          "#E7590D",
+        ]}
+        swatchesPerRow={7}
+        value={form.data.color}
+        onChange={(color) => updateValue("color", color)}
+        error={form.errors.color}
       />
 
       <Flex justify="flex-end" mt="xl">

--- a/resources/js/pages/Projects/Tasks/Index/TaskGroup.jsx
+++ b/resources/js/pages/Projects/Tasks/Index/TaskGroup.jsx
@@ -17,7 +17,8 @@ export default function TaskGroup({ group, tasks, ...props }) {
           ref={provided.innerRef}
           {...provided.draggableProps}
         >
-          <div className={classes.group}>
+          <div className={classes.group}
+           style={group.color ? { backgroundColor: group.color } : undefined}>
             <Group>
               <div {...provided.dragHandleProps} className={classes.dragHandle}>
                 <IconGripVertical


### PR DESCRIPTION
This PR introduces the ability to assign a color to each task group. The color is stored in the database and is used to visually distinguish task group headers in the UI.

Changes Included
Database Migration:
Added a nullable color column to the task_groups table.

Model Update:
Updated the TaskGroup model to include color in the $fillable array for mass assignment.

Validation:
Added validation for the color attribute in both StoreTaskGroupRequest and UpdateTaskGroupRequest.

Frontend:

Added a color picker input to the task group edit modal.
The selected color is saved and used to style the header of each task group in the Kanban view.

How It Works:
When editing a task group, users can select a color using the color picker.
The selected color is saved to the database and immediately reflected in the UI.
If no color is selected, the default background color is used.

Motivation:
Adding color to task groups improves visual organization and usability, especially for boards with many groups.

Testing:
Verified that the color can be set, updated, and cleared via the UI.
Confirmed that the color is persisted in the database and displayed correctly in the Kanban view.
Ensured backward compatibility for existing task groups without a color.