### PR TITLE
feat: add color attribute to task groups (migration, model, validaton, UI)

### DIFF
--- a/app/Http/Requests/TaskGroup/StoreTaskGroupRequest.php
+++ b/app/Http/Requests/TaskGroup/StoreTaskGroupRequest.php
@@ -22,13 +22,19 @@ class StoreTaskGroupRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
-            'name' => [
-                'required',
-                'string',
-                Rule::unique('task_groups', 'name')
-                    ->where('project_id', $this->route('project')->id),
-            ],
-        ];
+         return [
+        'name' => [
+            'required',
+            'string',
+            Rule::unique('task_groups', 'name')
+                ->where('project_id', $this->route('project')->id)
+                ->ignore($this->route('taskGroup')->id),
+        ],
+        'color' => [
+            'nullable',
+            'string',
+            'max:16',
+        ],
+         ];
     }
 }

--- a/app/Http/Requests/TaskGroup/UpdateTaskGroupRequest.php
+++ b/app/Http/Requests/TaskGroup/UpdateTaskGroupRequest.php
@@ -22,14 +22,19 @@ class UpdateTaskGroupRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
-            'name' => [
-                'required',
-                'string',
-                Rule::unique('task_groups', 'name')
-                    ->where('project_id', $this->route('project')->id)
-                    ->ignore($this->route('taskGroup')->id),
-            ],
-        ];
+         return [
+        'name' => [
+            'required',
+            'string',
+            Rule::unique('task_groups', 'name')
+                ->where('project_id', $this->route('project')->id)
+                ->ignore($this->route('taskGroup')->id),
+        ],
+        'color' => [
+            'nullable',
+            'string',
+            'max:16',
+        ],
+         ];
     }
 }

--- a/app/Models/TaskGroup.php
+++ b/app/Models/TaskGroup.php
@@ -19,7 +19,7 @@ class TaskGroup extends Model implements AuditableContract, Sortable
 
     public $timestamps = false;
 
-    protected $fillable = ['name', 'project_id', 'order_column'];
+    protected $fillable = ['name','color', 'project_id', 'order_column'];
 
     protected static function booted(): void
     {

--- a/database/migrations/2025_12_15_090401_add_color_to_task_groups_table.php
+++ b/database/migrations/2025_12_15_090401_add_color_to_task_groups_table.php
@@ -1,0 +1,21 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('task_groups', function (Blueprint $table) {
+            $table->string('color', 16)->nullable()->after('name');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('task_groups', function (Blueprint $table) {
+            $table->dropColumn('color');
+        });
+    }
+};

--- a/resources/js/pages/Projects/Tasks/Index/Modals/EditTasksGroupModal.jsx
+++ b/resources/js/pages/Projects/Tasks/Index/Modals/EditTasksGroupModal.jsx
@@ -1,5 +1,5 @@
 import useForm from "@/hooks/useForm";
-import { Button, Flex, Text, TextInput } from "@mantine/core";
+import { Button, Flex, Text, TextInput, ColorInput } from "@mantine/core";
 import { modals } from "@mantine/modals";
 
 function ModalForm({ item }) {
@@ -9,6 +9,7 @@ function ModalForm({ item }) {
     {
       _method: "put",
       name: item.name || "",
+      color: item.color || "",
     },
   );
 
@@ -29,6 +30,31 @@ function ModalForm({ item }) {
         value={form.data.name}
         onChange={(e) => updateValue("name", e.target.value)}
         error={form.errors.name}
+      />
+
+      <ColorInput
+        label="Color"
+        placeholder="Group color"
+        mt="md"
+        swatches={[
+          "#343A40",
+          "#E03231",
+          "#C2255C",
+          "#9C36B5",
+          "#6741D9",
+          "#3B5BDB",
+          "#2771C2",
+          "#2A8599",
+          "#2B9267",
+          "#309E44",
+          "#66A810",
+          "#F08C00",
+          "#E7590D",
+        ]}
+        swatchesPerRow={7}
+        value={form.data.color}
+        onChange={(color) => updateValue("color", color)}
+        error={form.errors.color}
       />
 
       <Flex justify="flex-end" mt="xl">

--- a/resources/js/pages/Projects/Tasks/Index/TaskGroup.jsx
+++ b/resources/js/pages/Projects/Tasks/Index/TaskGroup.jsx
@@ -17,7 +17,8 @@ export default function TaskGroup({ group, tasks, ...props }) {
           ref={provided.innerRef}
           {...provided.draggableProps}
         >
-          <div className={classes.group}>
+          <div className={classes.group}
+           style={group.color ? { backgroundColor: group.color } : undefined}>
             <Group>
               <div {...provided.dragHandleProps} className={classes.dragHandle}>
                 <IconGripVertical


### PR DESCRIPTION
This PR introduces the ability to assign a color to each task group. The color is stored in the database and is used to visually distinguish task group headers in the UI.

Changes Included
Database Migration:
Added a nullable color column to the task_groups table.

Model Update:
Updated the TaskGroup model to include color in the $fillable array for mass assignment.

Validation:
Added validation for the color attribute in both StoreTaskGroupRequest and UpdateTaskGroupRequest.

Frontend:

Added a color picker input to the task group edit modal.
The selected color is saved and used to style the header of each task group in the Kanban view.

How It Works:
When editing a task group, users can select a color using the color picker.
The selected color is saved to the database and immediately reflected in the UI.
If no color is selected, the default background color is used.

Motivation:
Adding color to task groups improves visual organization and usability, especially for boards with many groups.

Testing:
Verified that the color can be set, updated, and cleared via the UI.
Confirmed that the color is persisted in the database and displayed correctly in the Kanban view.
Ensured backward compatibility for existing task groups without a color.